### PR TITLE
feat: Implement Create List screen

### DIFF
--- a/app/src/main/java/az/siftoshka/librapp/App.kt
+++ b/app/src/main/java/az/siftoshka/librapp/App.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import az.siftoshka.data.di.dataModule
 import az.siftoshka.data.di.networkModule
 import az.siftoshka.domain.di.useCaseModule
+import az.siftoshka.presentation.di.createListPresentationModule
 import az.siftoshka.presentation.di.homePresentationModule
 import az.siftoshka.presentation.di.onboardingPresentationModule
 import org.koin.android.ext.koin.androidContext
@@ -24,7 +25,8 @@ class App: Application(), KoinStartup {
             networkModule,
             useCaseModule,
             onboardingPresentationModule,
-            homePresentationModule
+            homePresentationModule,
+            createListPresentationModule
         )
     }
 }

--- a/app/src/main/java/az/siftoshka/librapp/navigation/NavGraph.kt
+++ b/app/src/main/java/az/siftoshka/librapp/navigation/NavGraph.kt
@@ -5,6 +5,9 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.navigation
 import az.siftoshka.presentation.navigation.SubGraph
+import az.siftoshka.presentation.navigation.createlist.CreateListRoute
+import az.siftoshka.presentation.navigation.createlist.CreateListSubGraph
+import az.siftoshka.presentation.navigation.createlist.createListNavigation
 import az.siftoshka.presentation.navigation.home.HomeRoute
 import az.siftoshka.presentation.navigation.home.HomeSubGraph
 import az.siftoshka.presentation.navigation.home.homeNavigation
@@ -29,6 +32,11 @@ fun NavGraph(
         }
         navigation<HomeSubGraph.Main>(startDestination = HomeRoute.Home) {
             homeNavigation(
+                onBack = navController::navigateUp
+            )
+        }
+        navigation<CreateListSubGraph.Main>(startDestination = CreateListRoute.CreateList) {
+            createListNavigation(
                 onBack = navController::navigateUp
             )
         }

--- a/presentation/src/main/java/az/siftoshka/presentation/di/CreateListPresentationModule.kt
+++ b/presentation/src/main/java/az/siftoshka/presentation/di/CreateListPresentationModule.kt
@@ -1,0 +1,9 @@
+package az.siftoshka.presentation.di
+
+import az.siftoshka.presentation.feature.createlist.CreateListViewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.dsl.module
+
+val createListPresentationModule = module {
+    viewModelOf(::CreateListViewModel)
+}

--- a/presentation/src/main/java/az/siftoshka/presentation/feature/createlist/CreateListContract.kt
+++ b/presentation/src/main/java/az/siftoshka/presentation/feature/createlist/CreateListContract.kt
@@ -1,0 +1,15 @@
+package az.siftoshka.presentation.feature.createlist
+
+import az.siftoshka.presentation.feature.base.UIEffect
+import az.siftoshka.presentation.feature.base.UIEvent
+import az.siftoshka.presentation.feature.base.UIState
+
+class CreateListContract {
+    sealed class Event : UIEvent {
+    }
+
+    data object State : UIState
+
+    sealed class Effect : UIEffect {
+    }
+}

--- a/presentation/src/main/java/az/siftoshka/presentation/feature/createlist/CreateListScreen.kt
+++ b/presentation/src/main/java/az/siftoshka/presentation/feature/createlist/CreateListScreen.kt
@@ -1,0 +1,34 @@
+package az.siftoshka.presentation.feature.createlist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import az.siftoshka.presentation.uikit.base.PredictiveSurface
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun CreateListScreen(
+    onBack: () -> Unit,
+    viewModel: CreateListViewModel = koinViewModel()
+) {
+    PredictiveSurface(onBack = onBack) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "CreateListScreen",
+                style = MaterialTheme.typography.headlineLarge,
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/az/siftoshka/presentation/feature/createlist/CreateListViewModel.kt
+++ b/presentation/src/main/java/az/siftoshka/presentation/feature/createlist/CreateListViewModel.kt
@@ -1,0 +1,8 @@
+package az.siftoshka.presentation.feature.createlist
+
+import az.siftoshka.presentation.feature.base.BaseViewModel
+
+class CreateListViewModel : BaseViewModel<CreateListContract.State, CreateListContract.Effect, CreateListContract.Event>() {
+
+    override fun setInitialState() = CreateListContract.State
+}

--- a/presentation/src/main/java/az/siftoshka/presentation/navigation/createlist/CreateListDestinations.kt
+++ b/presentation/src/main/java/az/siftoshka/presentation/navigation/createlist/CreateListDestinations.kt
@@ -1,0 +1,7 @@
+package az.siftoshka.presentation.navigation.createlist
+
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+
+fun NavController.navCreateList(navOptions: NavOptions? = null) =
+    navigate(CreateListRoute.CreateList, navOptions)

--- a/presentation/src/main/java/az/siftoshka/presentation/navigation/createlist/CreateListNavigation.kt
+++ b/presentation/src/main/java/az/siftoshka/presentation/navigation/createlist/CreateListNavigation.kt
@@ -1,0 +1,15 @@
+package az.siftoshka.presentation.navigation.createlist
+
+import androidx.navigation.NavGraphBuilder
+import az.siftoshka.presentation.feature.createlist.CreateListScreen
+import az.siftoshka.presentation.uikit.utils.animatedComposable
+
+fun NavGraphBuilder.createListNavigation(
+    onBack: () -> Unit,
+) {
+    animatedComposable<CreateListRoute.CreateList> {
+        CreateListScreen(
+            onBack = onBack
+        )
+    }
+}

--- a/presentation/src/main/java/az/siftoshka/presentation/navigation/createlist/CreateListRoute.kt
+++ b/presentation/src/main/java/az/siftoshka/presentation/navigation/createlist/CreateListRoute.kt
@@ -1,0 +1,10 @@
+package az.siftoshka.presentation.navigation.createlist
+
+import az.siftoshka.presentation.navigation.Screen
+import kotlinx.serialization.Serializable
+
+sealed class CreateListRoute : Screen {
+
+    @Serializable
+    data object CreateList : Screen
+}

--- a/presentation/src/main/java/az/siftoshka/presentation/navigation/createlist/CreateListSubGraph.kt
+++ b/presentation/src/main/java/az/siftoshka/presentation/navigation/createlist/CreateListSubGraph.kt
@@ -1,0 +1,10 @@
+package az.siftoshka.presentation.navigation.createlist
+
+import az.siftoshka.presentation.navigation.SubGraph
+import kotlinx.serialization.Serializable
+
+sealed class CreateListSubGraph : SubGraph {
+
+    @Serializable
+    data object Main : SubGraph
+}


### PR DESCRIPTION
This commit introduces the initial implementation of the Create List screen.

The following changes were made:
- Created `CreateListContract.kt`, `CreateListViewModel.kt`, and `CreateListScreen.kt` for the Create List feature.
- Added navigation components: `CreateListRoute.kt`, `CreateListDestinations.kt`, `CreateListNavigation.kt`, and `CreateListSubGraph.kt`.
- Updated Koin dependency injection module to include `CreateListViewModel`.
- Integrated the Create List screen into the main navigation graph (`NavGraph.kt`).
- The `CreateListScreen` currently displays a placeholder text "CreateListScreen".

This provides the basic structure for the Create List feature, allowing for further UI and business logic development.